### PR TITLE
Don't mount or create symlinks that already exist

### DIFF
--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -40,7 +40,8 @@ sanitize_cgroups() {
   done
 
   mkdir -p /sys/fs/cgroup/systemd
-  mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
+  mountpoint -q /sys/fs/cgroup/systemd || \
+    mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
 }
 
 start_docker() {

--- a/docker.sh
+++ b/docker.sh
@@ -42,8 +42,13 @@ fi
 mkdir -p ${cache_mount}/${cache_team}
 mkdir -p $(dirname ${cache_dir})
 
-ln -s ${cache_mount}/${cache_team} ${cache_dir}
+if [ ! -L ${cache_dir}/${cache_team} ]; then
+  ln -s ${cache_mount}/${cache_team} ${cache_dir}
+fi
+
 # deprecated old cache dir location
-ln -s ${cache_mount}/${cache_team} /halfpipe-shared-cache
+if [ ! -L /halfpipe-shared-cache ]; then
+  ln -s ${cache_mount}/${cache_team} /halfpipe-shared-cache
+fi
 
 exec bash -c "$@"


### PR DESCRIPTION
This is mainly useful when running `docker.sh` several times. These changes are meant to prevent these sorts of warnings on subsequent runs:

```
mount: cgroup is already mounted or /sys/fs/cgroup/systemd busy
       cgroup is already mounted on /sys/fs/cgroup
       cgroup is already mounted on /sys/fs/cgroup/systemd
       cgroup is already mounted on /sys/fs/cgroup/cpuset
       cgroup is already mounted on /sys/fs/cgroup/cpu,cpuacct
       cgroup is already mounted on /sys/fs/cgroup/blkio
       cgroup is already mounted on /sys/fs/cgroup/memory
       cgroup is already mounted on /sys/fs/cgroup/devices
       cgroup is already mounted on /sys/fs/cgroup/freezer
       cgroup is already mounted on /sys/fs/cgroup/perf_event
       cgroup is already mounted on /sys/fs/cgroup/net_cls,net_prio
       cgroup is already mounted on /sys/fs/cgroup/hugetlb
       cgroup is already mounted on /sys/fs/cgroup/pids
       cgroup is already mounted on /sys/fs/cgroup/rdma
Docker version 18.09.6, build 481bc77
docker-compose version 1.24.0, build 0aa5906
Cache dir available: /var/halfpipe/shared-cache
ln: failed to create symbolic link '/var/halfpipe/shared-cache/common': File exists
ln: failed to create symbolic link '/halfpipe-shared-cache/common': File exists
```

I have only tested this on my machine, not inside a Concourse pipeline (as it is a bit tedious to build and upload my own version of `eu.gcr.io/halfpipe-io/halfpipe-docker-compose`).